### PR TITLE
CI: Don't rebuild dist files for demo deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ jobs:
           name: Install jsonpanel-next dependencies
           command: npm install
       - run:
-          name: Build jsonpanel-next
-          command: npm run build
-      - run:
           name: Prepare demo directory for deployment
           command: npm run prep-demo
       - run:


### PR DESCRIPTION
The `dist/` library files are already committed, we don't need to rebuild them again when deploying the demo site.