### PR TITLE
Fix monospace fonts for JSONPanel preview

### DIFF
--- a/demo/index.css
+++ b/demo/index.css
@@ -12,9 +12,12 @@ body {
 }
 
 .jsonpanel {
-  font-family: 'Source Code Pro', monospace;
   border: 1px;
   border-style: dashed;
+}
+
+.jsonpanel * {
+  font-family: 'Source Code Pro', monospace;
 }
 
 h1 {


### PR DESCRIPTION
Previously, the monospace font was not being applied correctly to the panel.